### PR TITLE
Bump AWS provider version

### DIFF
--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.74"
+      version = "~> 4.25"
     }
   }
 }

--- a/providers.tf
+++ b/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.74"
+      version = "~> 4.25"
     }
   }
 }


### PR DESCRIPTION
This module relies on some other AWS submodules which use a different AWS provider version. This causes Terraform not to be able to locate a provider version matching the version requirements.

```
➜ terraform init

Initializing the backend...
Initializing modules...
Downloading registry.terraform.io/PaloAltoNetworks/vmseries-modules/aws 0.4.1 for security_subnet_sets...
- security_subnet_sets in .terraform/modules/security_subnet_sets/modules/subnet_set
Downloading registry.terraform.io/PaloAltoNetworks/vmseries-modules/aws 0.4.1 for security_vpc...
- security_vpc in .terraform/modules/security_vpc/modules/vpc
Downloading registry.terraform.io/PaloAltoNetworks/vmseries-modules/aws 0.4.1 for security_vpc_routes...
- security_vpc_routes in .terraform/modules/security_vpc_routes/modules/vpc_route
- vmseries in ../..

Initializing provider plugins...
- Finding hashicorp/aws versions matching "~> 3.74, ~> 4.25"...
╷
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints ~> 3.74, ~>
│ 4.25
╵
```

```
❯ terraform providers

Providers required by configuration:
.
├── provider[registry.terraform.io/hashicorp/aws] ~> 3.74
├── module.security_vpc
│   └── provider[registry.terraform.io/hashicorp/aws] ~> 4.25
├── module.security_vpc_routes
│   └── provider[registry.terraform.io/hashicorp/aws] ~> 4.25
├── module.vmseries
│   └── provider[registry.terraform.io/hashicorp/aws] ~> 3.74
└── module.security_subnet_sets
    └── provider[registry.terraform.io/hashicorp/aws] ~> 4.25
```